### PR TITLE
Add frailty to data generating process.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: AllelicSeries
 Title: Allelic Series Test
-Version: 0.0.2.4
+Version: 0.0.2.5
 Authors@R:
     c(person(given = "Zachary",
            family = "McCaw",

--- a/man/DGP.Rd
+++ b/man/DGP.Rd
@@ -18,6 +18,7 @@ DGP(
   p_ptv = 0.1,
   prop_causal = 1,
   random_signs = FALSE,
+  random_var = 0,
   snps = 100,
   weights = c(1, 2, 3)
 )
@@ -56,6 +57,8 @@ Biobank.}
 
 \item{random_signs}{Randomize signs? FALSE for burden-type genetic
 architecture, TRUE for SKAT-type.}
+
+\item{random_var}{Frailty variance in the case of random signs. Default: 0.}
 
 \item{snps}{Number of SNP in the gene. Default: 100.}
 

--- a/man/GenPheno.Rd
+++ b/man/GenPheno.Rd
@@ -16,6 +16,7 @@ GenPheno(
   method = "none",
   prop_causal = 1,
   random_signs = FALSE,
+  random_var = 0,
   weights = c(0, 1, 2)
 )
 }
@@ -43,6 +44,8 @@ value. Intended for testing.}
 
 \item{random_signs}{Randomize signs? FALSE for burden-type genetic
 architecture, TRUE for SKAT-type.}
+
+\item{random_var}{Frailty variance in the case of random signs. Default: 0.}
 
 \item{weights}{Aggregation weights.}
 }

--- a/tests/testthat/test-data_generation.R
+++ b/tests/testthat/test-data_generation.R
@@ -238,3 +238,47 @@ test_that("Check ability to vary the proportion of causal variants.", {
   expect_equal(external_pheno, internal_pheno)
   
 })
+
+
+test_that("Checking ability to generate phenotypes with random genetic effects.", {
+  
+  anno <- c(0, 1, 2)
+  geno <- rbind(
+    c(0, 0, 0),
+    c(1, 1, 1),
+    c(0, 2, 0),
+    c(1, 0, 2)
+  )
+  covar <- c(rep(1, 4))
+  beta <- c(1, 2, 3)
+  reg_param <- list(coef = as.matrix(0))
+  weights <- c(1, 1, 1)
+  
+  withr::local_seed(123)
+  y_nonrandom <- GenPheno(
+    anno = anno,
+    beta = beta,
+    covar = covar,
+    geno = geno,
+    reg_param = reg_param,
+    include_residual = FALSE,
+    random_signs = TRUE,
+    random_var = 0.0
+  )
+  
+  withr::local_seed(123)
+  y_random <- GenPheno(
+    anno = anno,
+    beta = beta,
+    covar = covar,
+    geno = geno,
+    reg_param = reg_param,
+    include_residual = FALSE,
+    random_signs = TRUE,
+    random_var = 1.0
+  )
+  
+  expect_gt(stats::var(y_random), stats::var(y_nonrandom))
+  
+})
+


### PR DESCRIPTION
Add a frailty term to scale the effect size magnitude when simulating SKAT-type phenotypes. 