### PR TITLE
Linking GitHub to CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Authors@R:
     )
 Description: Implementation of gene-level rare variant association tests targeting allelic series: genes where increasingly deleterious mutations have increasingly large phenotypic effects. The COding-variant Allelic Series Test (COAST) operates on the benign missense variants (BMVs), deleterious missense variants (DMVs), and protein truncating variants (PTVs) within a gene. COAST uses a set of adjustable weights that tailor the test towards rejecting the null hypothesis for genes where the average magnitude of effect increases monotonically from BMVs to DMVs to PTVs. See McCaw ZR, O’Dushlaine C, Somineni H, Bereket M, Klein C, Karaletsos T, Casale FP, Koller D, Soare TW. (2023) "An allelic series rare variant association test for candidate gene discovery" <doi:10.1016/j.ajhg.2023.07.001>. 
 License: BSD_3_clause + file LICENSE
+URL: https://github.com/insitro/AllelicSeries
 Encoding: UTF-8
 Imports:
     CompQuadForm,

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 README
 ================
-2024-10-24
+2024-11-05
 
 # Allelic Series
 
+[![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/AllelicSeries)](https://cran.r-project.org/package=AllelicSeries)
 [![](https://cranlogs.r-pkg.org/badges/grand-total/AllelicSeries)](https://CRAN.R-project.org/package=AllelicSeries)
 
 This package implements gene-level rare variant association tests


### PR DESCRIPTION
As suggested by [dvg-p4](https://github.com/dvg-p4), added GitHub URL to package description, and CRAN version badge to GitHub README.